### PR TITLE
CIS2 Fractionalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ marketplace-contract/module.wasm
 marketplace-contract/schema.bin
 cis2-nft/module.wasm
 cis2-nft/schema.bin
+cis2-fractionalizer/module.wasm
+cis2-fractionalizer/schema.bin
 .vscode
 Cargo.lock
 target

--- a/cis2-fractionalizer/.gitignore
+++ b/cis2-fractionalizer/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/cis2-fractionalizer/Cargo.toml
+++ b/cis2-fractionalizer/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cis2-multi"
+version = "0.1.0"
+authors = ["Concordium <developers@concordium.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[features]
+default = ["std"]
+std = ["concordium-std/std", "concordium-cis2/std"]
+
+[dependencies]
+concordium-std = { version = "*", default-features = false }
+concordium-cis2 = { version = "*", default-features = false }
+hex = "*"
+
+[lib]
+crate-type=["cdylib", "rlib"]
+
+[profile.release]
+codegen-units = 1
+opt-level = "s"

--- a/cis2-fractionalizer/README.md
+++ b/cis2-fractionalizer/README.md
@@ -1,0 +1,10 @@
+## Build
+
+- ### [Install tools for development](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#setup-tools)
+- ### [Build the Smart Contract Module](https://developer.concordium.software/en/mainnet/smart-contracts/guides/compile-module.html)
+  - Make sure your working directory is [cis2-fractionalizer](./) ie `cd cis2-fractionalizer`.
+  - Execute the following commands
+    ```bash
+    cis2-fractionalizer$ cargo concordium build --out ./module.wasm --schema-out ./schema.bin
+    ```
+  - You should have [module file](./module.wasm) & [schema file](./schema.bin) if everything has executed normally

--- a/cis2-fractionalizer/src/cis2_client.rs
+++ b/cis2-fractionalizer/src/cis2_client.rs
@@ -1,0 +1,85 @@
+//! CIS2 client is the intermediatory layer between marketplace contract and CIS2 contract.
+//!
+//! # Description
+//! It allows Marketplace contract to abstract away logic of calling CIS2 contract for the following methods
+//! - `supports_cis2` : Calls [`supports`](https://proposals.concordium.software/CIS/cis-0.html#supports)
+//! - `is_operator_of` : Calls [`operatorOf`](https://proposals.concordium.software/CIS/cis-2.html#operatorof)
+//! - `get_balance` : Calls [`balanceOf`](https://proposals.concordium.software/CIS/cis-2.html#balanceof)
+//! - `transfer` : Calls [`transfer`](https://proposals.concordium.software/CIS/cis-2.html#transfer)
+
+use std::vec;
+
+use concordium_cis2::*;
+use concordium_std::*;
+
+use crate::state::State;
+
+pub const TRANSFER_ENTRYPOINT_NAME: &str = "transfer";
+
+#[derive(Serialize, Debug, PartialEq, Eq, Reject, SchemaType)]
+pub enum Cis2ClientError {
+    InvokeContractError,
+    ParseParams,
+}
+
+pub struct Cis2Client;
+
+impl Cis2Client {
+    pub(crate) fn transfer<
+        S,
+        T: IsTokenId + Clone + Copy,
+        A: IsTokenAmount + Clone + Copy + ops::Sub<Output = A>,
+    >(
+        host: &mut impl HasHost<State<S>, StateApiType = S>,
+        token_id: T,
+        nft_contract_address: ContractAddress,
+        amount: A,
+        from: Address,
+        to: Receiver,
+    ) -> Result<(), Cis2ClientError>
+    where
+        S: HasStateApi,
+        A: IsTokenAmount,
+    {
+        let params = TransferParams(vec![Transfer {
+            token_id,
+            amount,
+            from,
+            data: AdditionalData::empty(),
+            to,
+        }]);
+
+        Cis2Client::invoke_contract_read_only(
+            host,
+            &nft_contract_address,
+            TRANSFER_ENTRYPOINT_NAME,
+            &params,
+        )?;
+
+        Ok(())
+    }
+
+    fn invoke_contract_read_only<S: HasStateApi, R: Deserial, P: Serial>(
+        host: &mut impl HasHost<State<S>, StateApiType = S>,
+        contract_address: &ContractAddress,
+        entrypoint_name: &str,
+        params: &P,
+    ) -> Result<R, Cis2ClientError> {
+        let invoke_contract_result = host
+            .invoke_contract_read_only(
+                contract_address,
+                params,
+                EntrypointName::new(entrypoint_name).unwrap_abort(),
+                Amount::from_ccd(0),
+            )
+            .map_err(|_e| Cis2ClientError::InvokeContractError)?;
+        let mut invoke_contract_res = match invoke_contract_result {
+            Some(s) => s,
+            None => return Result::Err(Cis2ClientError::InvokeContractError),
+        };
+        let parsed_res =
+            R::deserial(&mut invoke_contract_res).map_err(|_e| Cis2ClientError::ParseParams)?;
+
+        Ok(parsed_res)
+    }
+}

--- a/cis2-fractionalizer/src/contract.rs
+++ b/cis2-fractionalizer/src/contract.rs
@@ -64,6 +64,7 @@ fn contract_view<S: HasStateApi>(
     Ok(ViewState {
         state: inner_state,
         tokens,
+        collaterals: state.collaterals.iter().map(|(a, b)| (*a, *b)).collect(),
     })
 }
 

--- a/cis2-fractionalizer/src/contract.rs
+++ b/cis2-fractionalizer/src/contract.rs
@@ -1,0 +1,953 @@
+use concordium_cis2::*;
+use concordium_std::*;
+
+use crate::{
+    cis2_client::Cis2Client,
+    error::{ContractError, CustomContractError},
+    params::{
+        ContractBalanceOfQueryParams, ContractBalanceOfQueryResponse, MintParams,
+        SetImplementorsParams, TransferParameter, ViewAddressState, ViewState,
+    },
+    state::State,
+    ContractResult, ContractTokenAmount, ContractTokenId, SUPPORTS_STANDARDS,
+};
+
+// Contract functions
+/// Initialize contract instance with a no token types.
+#[init(contract = "CIS2-Fractionalizer")]
+fn contract_init<S: HasStateApi>(
+    _ctx: &impl HasInitContext,
+    state_builder: &mut StateBuilder<S>,
+) -> InitResult<State<S>> {
+    // Construct the initial contract state.
+    Ok(State::empty(state_builder))
+}
+
+/// View function for testing. This reports on the entire state of the contract
+/// for testing purposes. In a realistic example there `balance_of` and similar
+/// functions with a smaller response.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "view",
+    return_value = "ViewState"
+)]
+fn contract_view<S: HasStateApi>(
+    _ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ReceiveResult<ViewState> {
+    let state = host.state();
+
+    let mut inner_state = Vec::new();
+    for (k, a_state) in state.state.iter() {
+        let mut balances = Vec::new();
+        let mut operators = Vec::new();
+        for (token_id, amount) in a_state.balances.iter() {
+            balances.push((*token_id, *amount));
+        }
+        for o in a_state.operators.iter() {
+            operators.push(*o);
+        }
+
+        inner_state.push((
+            *k,
+            ViewAddressState {
+                balances,
+                operators,
+            },
+        ));
+    }
+    let mut tokens = Vec::new();
+    for v in state.tokens.iter() {
+        tokens.push(v.0.to_owned());
+    }
+
+    Ok(ViewState {
+        state: inner_state,
+        tokens,
+    })
+}
+
+/// Mint new tokens with a given address as the owner of these tokens.
+/// Can only be called by the contract owner.
+/// Logs a `Mint` and a `TokenMetadata` event for each token.
+/// The url for the token metadata is the token ID encoded in hex, appended on
+/// the `TOKEN_METADATA_BASE_URL`.
+///
+/// It rejects if:
+/// - The sender is not the contract instance owner.
+/// - Fails to parse parameter.
+/// - Any of the tokens fails to be minted, which could be if:
+///     - Fails to log Mint event.
+///     - Fails to log TokenMetadata event.
+///
+/// Note: Can at most mint 32 token types in one call due to the limit on the
+/// number of logs a smart contract can produce on each function call.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "mint",
+    parameter = "MintParams",
+    error = "ContractError",
+    enable_logger,
+    mutable
+)]
+fn contract_mint<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+    logger: &mut impl HasLogger,
+) -> ContractResult<()> {
+    let sender = match ctx.sender() {
+        Address::Account(a) => a,
+        Address::Contract(_) => bail!(CustomContractError::AccountsOnly.into()),
+    };
+
+    // Parse the parameter.
+    let params: MintParams = ctx.parameter_cursor().get()?;
+
+    let (state, builder) = host.state_and_builder();
+    for (token_id, token_info) in params.tokens {
+        ensure!(
+            state.has_collateral(&token_info.contract, &token_info.token_id, &sender),
+            concordium_cis2::Cis2Error::Custom(CustomContractError::InvalidCollateral)
+        );
+
+        // Mint the token in the state.
+        state.mint(
+            &token_id,
+            &token_info.metadata,
+            token_info.amount,
+            &params.owner,
+            builder,
+        );
+
+        state.update_collateral_token(
+            token_info.contract,
+            token_info.token_id,
+            sender,
+            token_id,
+        )?;
+
+        // Event for minted token.
+        logger.log(&Cis2Event::Mint(MintEvent {
+            token_id,
+            amount: token_info.amount,
+            owner: params.owner,
+        }))?;
+
+        // Metadata URL for the token.
+        logger.log(&Cis2Event::TokenMetadata::<_, ContractTokenAmount>(
+            TokenMetadataEvent {
+                token_id,
+                metadata_url: token_info.metadata.to_metadata_url(),
+            },
+        ))?;
+    }
+    Ok(())
+}
+
+/// Execute a list of token transfers, in the order of the list.
+/// If the transfer is to the self address the tokens are burned instead.
+/// If the balance after burning is zero then the collateral is returned back to the original sender.
+///
+/// Logs a `Transfer` event and invokes a receive hook function for every
+/// transfer in the list.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Any of the transfers fail to be executed, which could be if:
+///     - The `token_id` does not exist.
+///     - The sender is not the owner of the token, or an operator for this
+///       specific `token_id` and `from` address.
+///     - The token is not owned by the `from`.
+/// - Fails to log event.
+/// - Any of the receive hook function calls rejects.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "transfer",
+    parameter = "TransferParameter",
+    error = "ContractError",
+    enable_logger,
+    mutable
+)]
+fn contract_transfer<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+    logger: &mut impl HasLogger,
+) -> ContractResult<()> {
+    // Parse the parameter.
+    let TransferParams(transfers): TransferParameter = ctx.parameter_cursor().get()?;
+    // Get the sender who invoked this contract function.
+    let sender = ctx.sender();
+
+    for Transfer {
+        token_id,
+        amount,
+        from,
+        to,
+        data,
+    } in transfers
+    {
+        let (state, builder) = host.state_and_builder();
+        // Authenticate the sender for this transfer
+        ensure!(
+            from == sender || state.is_operator(&sender, &from),
+            ContractError::Unauthorized
+        );
+
+        if to.address().matches_contract(&ctx.self_address()) {
+            // tokens are being transferred to self
+            // burn the tokens
+            let remaining_amount: ContractTokenAmount = state.burn(&token_id, amount, &from)?;
+
+            // log burn event
+            logger.log(&Cis2Event::Burn(BurnEvent {
+                token_id,
+                amount,
+                owner: from,
+            }))?;
+
+            // Check of there is any remaining amount
+            if remaining_amount.eq(&ContractTokenAmount::from(0)) {
+                // Everything has been burned
+                // Transfer collateral back to the original owner
+                let (collateral_key, collateral_amount) = state
+                    .find_collateral(&token_id)
+                    .ok_or(Cis2Error::Custom(CustomContractError::InvalidCollateral))?;
+
+                // Return back the collateral
+                Cis2Client::transfer(
+                    host,
+                    collateral_key.token_id,
+                    collateral_key.contract,
+                    collateral_amount,
+                    concordium_std::Address::Contract(ctx.self_address()),
+                    concordium_cis2::Receiver::Account(collateral_key.owner),
+                )
+                .map_err(CustomContractError::Cis2ClientError)?;
+            }
+        } else {
+            let to_address = to.address();
+
+            // Tokens are being transferred to another address
+            // Update the contract state
+            state.transfer(&token_id, amount, &from, &to_address, builder)?;
+
+            // Log transfer event
+            logger.log(&Cis2Event::Transfer(TransferEvent {
+                token_id,
+                amount,
+                from,
+                to: to_address,
+            }))?;
+
+            // If the receiver is a contract we invoke it.
+            if let Receiver::Contract(address, entrypoint_name) = to {
+                let parameter = OnReceivingCis2Params {
+                    token_id,
+                    amount,
+                    from,
+                    data,
+                };
+                host.invoke_contract(
+                    &address,
+                    &parameter,
+                    entrypoint_name.as_entrypoint_name(),
+                    Amount::zero(),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Enable or disable addresses as operators of the sender address.
+/// Logs an `UpdateOperator` event.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Fails to log event.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "updateOperator",
+    parameter = "UpdateOperatorParams",
+    error = "ContractError",
+    enable_logger,
+    mutable
+)]
+fn contract_update_operator<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+    logger: &mut impl HasLogger,
+) -> ContractResult<()> {
+    // Parse the parameter.
+    let UpdateOperatorParams(params) = ctx.parameter_cursor().get()?;
+    // Get the sender who invoked this contract function.
+    let sender = ctx.sender();
+
+    let (state, builder) = host.state_and_builder();
+    for param in params {
+        // Update the operator in the state.
+        match param.update {
+            OperatorUpdate::Add => state.add_operator(&sender, &param.operator, builder),
+            OperatorUpdate::Remove => state.remove_operator(&sender, &param.operator),
+        }
+
+        // Log the appropriate event
+        logger.log(
+            &Cis2Event::<ContractTokenId, ContractTokenAmount>::UpdateOperator(
+                UpdateOperatorEvent {
+                    owner: sender,
+                    operator: param.operator,
+                    update: param.update,
+                },
+            ),
+        )?;
+    }
+    Ok(())
+}
+
+/// Get the balance of given token IDs and addresses.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Any of the queried `token_id` does not exist.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "balanceOf",
+    parameter = "ContractBalanceOfQueryParams",
+    return_value = "ContractBalanceOfQueryResponse",
+    error = "ContractError"
+)]
+fn contract_balance_of<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<ContractBalanceOfQueryResponse> {
+    // Parse the parameter.
+    let params: ContractBalanceOfQueryParams = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for query in params.queries {
+        // Query the state for balance.
+        let amount = host.state().balance(&query.token_id, &query.address)?;
+        response.push(amount);
+    }
+    let result = ContractBalanceOfQueryResponse::from(response);
+    Ok(result)
+}
+
+/// Takes a list of queries. Each query is an owner address and some address to
+/// check as an operator of the owner address.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "operatorOf",
+    parameter = "OperatorOfQueryParams",
+    return_value = "OperatorOfQueryResponse",
+    error = "ContractError"
+)]
+fn contract_operator_of<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<OperatorOfQueryResponse> {
+    // Parse the parameter.
+    let params: OperatorOfQueryParams = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for query in params.queries {
+        // Query the state for address being an operator of owner.
+        let is_operator = host.state().is_operator(&query.address, &query.owner);
+        response.push(is_operator);
+    }
+    let result = OperatorOfQueryResponse::from(response);
+    Ok(result)
+}
+
+/// Parameter type for the CIS-2 function `tokenMetadata` specialized to the
+/// subset of TokenIDs used by this contract.
+type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
+
+/// Get the token metadata URLs and checksums given a list of token IDs.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Any of the queried `token_id` does not exist.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "tokenMetadata",
+    parameter = "ContractTokenMetadataQueryParams",
+    return_value = "TokenMetadataQueryResponse",
+    error = "ContractError"
+)]
+fn contract_token_metadata<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<TokenMetadataQueryResponse> {
+    // Parse the parameter.
+    let params: ContractTokenMetadataQueryParams = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for token_id in params.queries {
+        let metadata_url: MetadataUrl = match host
+            .state()
+            .tokens
+            .get(&token_id)
+            .map(|metadata| metadata.to_owned())
+        {
+            Option::Some(m) => Result::Ok(m),
+            Option::None => Result::Err(ContractError::InvalidTokenId),
+        }?;
+
+        response.push(metadata_url);
+    }
+    let result = TokenMetadataQueryResponse::from(response);
+    Ok(result)
+}
+
+/// This functions should be invoked by any CIS2 Contract whose token is being transferred.
+/// TO this contract
+///
+/// Upon receiving any token its added to the collateral state of the contract.
+/// Mint function can be called in a separate transaction to mint a token against the collateral.
+///
+/// It rejects if:
+/// - Sender is not a contract.
+/// - It fails to parse the parameter.
+/// - Contract name part of the parameter is invalid.
+/// - Calling back `transfer` to sender contract rejects.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "onReceivingCIS2",
+    error = "ContractError",
+    mutable
+)]
+fn contract_on_cis2_received<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<()> {
+    // Ensure the sender is a contract.
+    let sender = if let Address::Contract(contract) = ctx.sender() {
+        contract
+    } else {
+        bail!(CustomContractError::ContractOnly.into())
+    };
+
+    // Parse the parameter.
+    let params: OnReceivingCis2Params<ContractTokenId, ContractTokenAmount> =
+        ctx.parameter_cursor().get()?;
+
+    let from_account = match params.from {
+        Address::Account(a) => a,
+        Address::Contract(_) => bail!(CustomContractError::ContractOnly.into()),
+    };
+
+    host.state_mut()
+        .add_collateral(sender, params.token_id, from_account, params.amount);
+    Ok(())
+}
+
+/// Get the supported standards or addresses for a implementation given list of
+/// standard identifiers.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "supports",
+    parameter = "SupportsQueryParams",
+    return_value = "SupportsQueryResponse",
+    error = "ContractError"
+)]
+fn contract_supports<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<SupportsQueryResponse> {
+    // Parse the parameter.
+    let params: SupportsQueryParams = ctx.parameter_cursor().get()?;
+
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for std_id in params.queries {
+        if SUPPORTS_STANDARDS.contains(&std_id.as_standard_identifier()) {
+            response.push(SupportResult::Support);
+        } else {
+            response.push(host.state().have_implementors(&std_id));
+        }
+    }
+    let result = SupportsQueryResponse::from(response);
+    Ok(result)
+}
+
+/// Set the addresses for an implementation given a standard identifier and a
+/// list of contract addresses.
+///
+/// It rejects if:
+/// - Sender is not the owner of the contract instance.
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-Fractionalizer",
+    name = "setImplementors",
+    parameter = "SetImplementorsParams",
+    error = "ContractError",
+    mutable
+)]
+fn contract_set_implementor<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<()> {
+    // Authorize the sender.
+    ensure!(
+        ctx.sender().matches_account(&ctx.owner()),
+        ContractError::Unauthorized
+    );
+    // Parse the parameter.
+    let params: SetImplementorsParams = ctx.parameter_cursor().get()?;
+    // Update the implementors in the state
+    host.state_mut()
+        .set_implementors(params.id, params.implementors);
+    Ok(())
+}
+
+// Tests
+#[concordium_cfg_test]
+mod tests {
+    use crate::params::{TokenMetadata, TokenMintParams};
+
+    use super::*;
+    use test_infrastructure::*;
+
+    const ACCOUNT_0: AccountAddress = AccountAddress([0u8; 32]);
+    const ADDRESS_0: Address = Address::Account(ACCOUNT_0);
+    const ACCOUNT_1: AccountAddress = AccountAddress([1u8; 32]);
+    const ADDRESS_1: Address = Address::Account(ACCOUNT_1);
+    const TOKEN_0: ContractTokenId = TokenIdU8(2);
+    const TOKEN_1: ContractTokenId = TokenIdU8(42);
+    const TOKEN_COLLATERAL_0: ContractTokenId = TokenIdU8(100);
+    const TOKEN_COLLATERAL_1: ContractTokenId = TokenIdU8(200);
+    const CONTRACT_COLLATERAL_0: ContractAddress = ContractAddress {
+        index: 1,
+        subindex: 0,
+    };
+
+    /// Test helper function which creates a contract state with two tokens with
+    /// id `TOKEN_0` and id `TOKEN_1` owned by `ADDRESS_0`
+    fn initial_state<S: HasStateApi>(state_builder: &mut StateBuilder<S>) -> State<S> {
+        let mut state = State::empty(state_builder);
+        state.mint(
+            &TOKEN_0,
+            &{
+                let url = "url".to_owned();
+                let hash =
+                    "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73".to_owned();
+                TokenMetadata { url, hash }
+            },
+            400.into(),
+            &ADDRESS_0,
+            state_builder,
+        );
+        state.mint(
+            &TOKEN_1,
+            &{
+                let url = "url".to_owned();
+                let hash =
+                    "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73".to_owned();
+                TokenMetadata { url, hash }
+            },
+            1.into(),
+            &ADDRESS_0,
+            state_builder,
+        );
+        state
+    }
+
+    /// Test initialization succeeds with a state with no tokens.
+    #[concordium_test]
+    fn test_init() {
+        // Setup the context
+        let ctx = TestInitContext::empty();
+        let mut builder = TestStateBuilder::new();
+
+        // Call the contract function.
+        let result = contract_init(&ctx, &mut builder);
+
+        // Check the result
+        let state = result.expect_report("Contract initialization failed");
+
+        // Check the state
+        claim_eq!(
+            state.tokens.iter().count(),
+            0,
+            "Only one token is initialized"
+        );
+    }
+
+    /// Test minting succeeds and the tokens are owned by the given address and
+    /// the appropriate events are logged.
+    #[concordium_test]
+    fn test_mint() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_0);
+        ctx.set_owner(ACCOUNT_0);
+
+        let url = "url".to_owned();
+        let hash = "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73".to_owned();
+        // and parameter.
+        let mut tokens = collections::BTreeMap::new();
+        tokens.insert(
+            TOKEN_0,
+            TokenMintParams {
+                amount: 400.into(),
+                token_id: TOKEN_COLLATERAL_0,
+                contract: CONTRACT_COLLATERAL_0,
+                metadata: TokenMetadata {
+                    url: url.to_string(),
+                    hash: hash.to_string(),
+                },
+            },
+        );
+        tokens.insert(
+            TOKEN_1,
+            TokenMintParams {
+                amount: 400.into(),
+                token_id: TOKEN_COLLATERAL_1,
+                contract: CONTRACT_COLLATERAL_0,
+                metadata: TokenMetadata { url, hash },
+            },
+        );
+        let parameter = MintParams {
+            owner: ADDRESS_0,
+            tokens,
+        };
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = TestLogger::init();
+        let mut state_builder = TestStateBuilder::new();
+        let state = State::empty(&mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+
+        // Call the contract function.
+        let result: ContractResult<()> = contract_mint(&ctx, &mut host, &mut logger);
+
+        // Check the result
+        claim!(result.is_ok(), "Results in rejection");
+
+        // Check the state
+        claim_eq!(
+            host.state().tokens.iter().count(),
+            2,
+            "Only one token is initialized"
+        );
+        let balance0 = host
+            .state()
+            .balance(&TOKEN_0, &ADDRESS_0)
+            .expect_report("Token is expected to exist");
+        claim_eq!(
+            balance0,
+            400.into(),
+            "Initial tokens are owned by the contract instantiater"
+        );
+
+        let balance1 = host
+            .state()
+            .balance(&TOKEN_1, &ADDRESS_0)
+            .expect_report("Token is expected to exist");
+        unsafe {
+            claim_eq!(
+                balance1,
+                1.into(),
+                "Initial tokens are owned by the contract instantiater"
+            );
+
+            // Check the logs
+            claim_eq!(logger.logs.len(), 4, "Exactly four events should be logged");
+            claim!(
+                logger.logs.contains(&to_bytes(&Cis2Event::Mint(MintEvent {
+                    owner: ADDRESS_0,
+                    token_id: TOKEN_0,
+                    amount: ContractTokenAmount::from(400),
+                }))),
+                "Expected an event for minting TOKEN_0"
+            );
+            claim!(
+                logger.logs.contains(&to_bytes(&Cis2Event::Mint(MintEvent {
+                    owner: ADDRESS_0,
+                    token_id: TOKEN_1,
+                    amount: ContractTokenAmount::from(1),
+                }))),
+                "Expected an event for minting TOKEN_1"
+            );
+
+            claim!(
+                logger.logs.contains(&to_bytes(
+                    &Cis2Event::TokenMetadata::<_, ContractTokenAmount>(TokenMetadataEvent {
+                        token_id: TOKEN_0,
+                        metadata_url: (TokenMetadata {
+                            url: "url".to_string(),
+                            hash:
+                                "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73"
+                                    .to_string()
+                        })
+                        .to_metadata_url(),
+                    })
+                )),
+                "Expected an event for token metadata for TOKEN_0"
+            );
+
+            claim!(
+                logger.logs.contains(&to_bytes(
+                    &Cis2Event::TokenMetadata::<_, ContractTokenAmount>(TokenMetadataEvent {
+                        token_id: TOKEN_1,
+                        metadata_url: (TokenMetadata {
+                            url: "url".to_string(),
+                            hash:
+                                "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73"
+                                    .to_string()
+                        })
+                        .to_metadata_url(),
+                    })
+                )),
+                "Expected an event for token metadata for TOKEN_1"
+            );
+        }
+    }
+
+    /// Test transfer succeeds, when `from` is the sender.
+    #[concordium_test]
+    fn test_transfer_account() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_0);
+
+        // and parameter.
+        let transfer = Transfer {
+            token_id: TOKEN_0,
+            amount: ContractTokenAmount::from(100),
+            from: ADDRESS_0,
+            to: Receiver::from_account(ACCOUNT_1),
+            data: AdditionalData::empty(),
+        };
+        let parameter = TransferParams::from(vec![transfer]);
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = TestLogger::init();
+        let mut state_builder = TestStateBuilder::new();
+        let state = initial_state(&mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+
+        // Call the contract function.
+        let result: ContractResult<()> = contract_transfer(&ctx, &mut host, &mut logger);
+        // Check the result.
+        claim!(result.is_ok(), "Results in rejection");
+
+        // Check the state.
+        let balance0 = host
+            .state()
+            .balance(&TOKEN_0, &ADDRESS_0)
+            .expect_report("Token is expected to exist");
+        let balance1 = host
+            .state()
+            .balance(&TOKEN_0, &ADDRESS_1)
+            .expect_report("Token is expected to exist");
+        claim_eq!(
+            balance0,
+            300.into(),
+            "Token owner balance should be decreased by the transferred amount."
+        );
+        claim_eq!(
+            balance1,
+            100.into(),
+            "Token receiver balance should be increased by the transferred amount"
+        );
+
+        // Check the logs.
+        claim_eq!(logger.logs.len(), 1, "Only one event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Cis2Event::Transfer(TransferEvent {
+                from: ADDRESS_0,
+                to: ADDRESS_1,
+                token_id: TOKEN_0,
+                amount: ContractTokenAmount::from(100),
+            })),
+            "Incorrect event emitted"
+        )
+    }
+
+    /// Test transfer token fails, when sender is neither the owner or an
+    /// operator of the owner.
+    #[concordium_test]
+    fn test_transfer_not_authorized() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_1);
+
+        // and parameter.
+        let transfer = Transfer {
+            from: ADDRESS_0,
+            to: Receiver::from_account(ACCOUNT_1),
+            token_id: TOKEN_0,
+            amount: ContractTokenAmount::from(100),
+            data: AdditionalData::empty(),
+        };
+        let parameter = TransferParams::from(vec![transfer]);
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = TestLogger::init();
+        let mut state_builder = TestStateBuilder::new();
+        let state = initial_state(&mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+
+        // Call the contract function.
+        let result: ContractResult<()> = contract_transfer(&ctx, &mut host, &mut logger);
+        // Check the result.
+        let err = result.expect_err_report("Expected to fail");
+        claim_eq!(
+            err,
+            ContractError::Unauthorized,
+            "Error is expected to be Unauthorized"
+        )
+    }
+
+    /// Test transfer succeeds when sender is not the owner, but is an operator
+    /// of the owner.
+    #[concordium_test]
+    fn test_operator_transfer() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_1);
+
+        // and parameter.
+        let transfer = Transfer {
+            from: ADDRESS_0,
+            to: Receiver::from_account(ACCOUNT_1),
+            token_id: TOKEN_0,
+            amount: ContractTokenAmount::from(100),
+            data: AdditionalData::empty(),
+        };
+        let parameter = TransferParams::from(vec![transfer]);
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = TestLogger::init();
+        let mut state_builder = TestStateBuilder::new();
+        let mut state = initial_state(&mut state_builder);
+        state.add_operator(&ADDRESS_0, &ADDRESS_1, &mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+
+        // Call the contract function.
+        let result: ContractResult<()> = contract_transfer(&ctx, &mut host, &mut logger);
+
+        // Check the result.
+        claim!(result.is_ok(), "Results in rejection");
+
+        // Check the state.
+        let balance0 = host
+            .state()
+            .balance(&TOKEN_0, &ADDRESS_0)
+            .expect_report("Token is expected to exist");
+        let balance1 = host
+            .state()
+            .balance(&TOKEN_0, &ADDRESS_1)
+            .expect_report("Token is expected to exist");
+        claim_eq!(
+            balance0,
+            300.into(),
+            "Token owner balance should be decreased by the transferred amount"
+        );
+        claim_eq!(
+            balance1,
+            100.into(),
+            "Token receiver balance should be increased by the transferred amount"
+        );
+
+        // Check the logs.
+        claim_eq!(logger.logs.len(), 1, "Only one event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Cis2Event::Transfer(TransferEvent {
+                from: ADDRESS_0,
+                to: ADDRESS_1,
+                token_id: TOKEN_0,
+                amount: ContractTokenAmount::from(100),
+            })),
+            "Incorrect event emitted"
+        )
+    }
+
+    /// Test adding an operator succeeds and the appropriate event is logged.
+    #[concordium_test]
+    fn test_add_operator() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_0);
+
+        // and parameter.
+        let update = UpdateOperator {
+            operator: ADDRESS_1,
+            update: OperatorUpdate::Add,
+        };
+        let parameter = UpdateOperatorParams(vec![update]);
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = TestLogger::init();
+        let mut state_builder = TestStateBuilder::new();
+        let state = initial_state(&mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+
+        // Call the contract function.
+        let result: ContractResult<()> = contract_update_operator(&ctx, &mut host, &mut logger);
+
+        // Check the result.
+        claim!(result.is_ok(), "Results in rejection");
+
+        // Check the state.
+        let is_operator = host.state().is_operator(&ADDRESS_1, &ADDRESS_0);
+        claim!(is_operator, "Account should be an operator");
+
+        // Checking that `ADDRESS_1` is an operator in the query response of the
+        // `contract_operator_of` function as well.
+        // Setup parameter.
+        let operator_of_query = OperatorOfQuery {
+            address: ADDRESS_1,
+            owner: ADDRESS_0,
+        };
+
+        let operator_of_query_vector = OperatorOfQueryParams {
+            queries: vec![operator_of_query],
+        };
+        let parameter_bytes = to_bytes(&operator_of_query_vector);
+
+        ctx.set_parameter(&parameter_bytes);
+
+        // Checking the return value of the `contract_operator_of` function
+        let result: ContractResult<OperatorOfQueryResponse> = contract_operator_of(&ctx, &host);
+
+        claim_eq!(
+            result.expect_report("Failed getting result value").0,
+            [true],
+            "Account should be an operator in the query response"
+        );
+
+        // Check the logs.
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(
+                &Cis2Event::<ContractTokenId, ContractTokenAmount>::UpdateOperator(
+                    UpdateOperatorEvent {
+                        owner: ADDRESS_0,
+                        operator: ADDRESS_1,
+                        update: OperatorUpdate::Add,
+                    }
+                )
+            ),
+            "Incorrect event emitted"
+        )
+    }
+}

--- a/cis2-fractionalizer/src/error.rs
+++ b/cis2-fractionalizer/src/error.rs
@@ -1,0 +1,65 @@
+use concordium_cis2::Cis2Error;
+use concordium_std::*;
+
+use crate::cis2_client::Cis2ClientError;
+
+pub type ContractError = Cis2Error<CustomContractError>;
+
+/// The different errors the contract can produce.
+#[derive(Serialize, Debug, PartialEq, Eq, Reject, SchemaType)]
+pub enum CustomContractError {
+    /// Failed parsing the parameter.
+    #[from(ParseError)]
+    ParseParams,
+    /// Failed logging: Log is full.
+    LogFull,
+    /// Failed logging: Log is malformed.
+    LogMalformed,
+    /// Invalid contract name.
+    InvalidContractName,
+    /// Only a smart contract can call this function.
+    ContractOnly,
+    /// Failed to invoke a contract.
+    InvokeContractError,
+    TokenAlreadyMinted,
+    InvalidCollateral,
+    NoBalanceToBurn,
+    AccountsOnly,
+    Cis2ClientError(Cis2ClientError),
+}
+
+/// Mapping the logging errors to ContractError.
+impl From<LogError> for CustomContractError {
+    fn from(le: LogError) -> Self {
+        match le {
+            LogError::Full => Self::LogFull,
+            LogError::Malformed => Self::LogMalformed,
+        }
+    }
+}
+
+/// Mapping errors related to contract invocations to CustomContractError.
+impl<T> From<CallContractError<T>> for CustomContractError {
+    fn from(_cce: CallContractError<T>) -> Self {
+        Self::InvokeContractError
+    }
+}
+
+/// Mapping CustomContractError to ContractError
+impl From<CustomContractError> for ContractError {
+    fn from(c: CustomContractError) -> Self {
+        Cis2Error::Custom(c)
+    }
+}
+
+impl From<NewReceiveNameError> for CustomContractError {
+    fn from(_: NewReceiveNameError) -> Self {
+        Self::InvalidContractName
+    }
+}
+
+impl From<NewContractNameError> for CustomContractError {
+    fn from(_: NewContractNameError) -> Self {
+        Self::InvalidContractName
+    }
+}

--- a/cis2-fractionalizer/src/lib.rs
+++ b/cis2-fractionalizer/src/lib.rs
@@ -1,0 +1,52 @@
+//! A multi token example implementation of the Concordium Token Standard CIS2.
+//!
+//! # Description
+//! An instance of this smart contract can contain a number of different token
+//! types each identified by a token ID. A token type is then globally
+//! identified by the contract address together with the token ID.
+//!
+//! In this example the contract is initialized with no tokens, and tokens can
+//! be minted through a `mint` contract function, which will only succeed for
+//! the contract owner. No functionality to burn token is defined in this
+//! example.
+//!
+//! Note: The word 'address' refers to either an account address or a
+//! contract address.
+//!
+//! As follows from the CIS2 specification, the contract has a `transfer`
+//! function for transferring an amount of a specific token type from one
+//! address to another address. An address can enable and disable one or more
+//! addresses as operators. An operator of some address is allowed to transfer
+//! any tokens owned by this address.
+//!
+//! This contract also contains an example of a function to be called when
+//! receiving tokens. In which case the contract will forward the tokens to
+//! the contract owner.
+//! This function is not very useful and is only there to showcase a simple
+//! implementation of a token receive hook.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+pub mod contract;
+mod error;
+mod params;
+mod state;
+mod cis2_client;
+
+use concordium_cis2::*;
+
+use crate::error::ContractError;
+
+/// List of supported standards by this contract address.
+const SUPPORTS_STANDARDS: [StandardIdentifier<'static>; 2] =
+    [CIS0_STANDARD_IDENTIFIER, CIS2_STANDARD_IDENTIFIER];
+
+// Types
+
+/// Contract token ID type.
+/// To save bytes we use a small token ID type, but is limited to be represented
+/// by a `u8`.
+type ContractTokenId = TokenIdU8;
+
+/// Contract token amount type.
+type ContractTokenAmount = TokenAmountU64;
+type ContractResult<A> = Result<A, ContractError>;

--- a/cis2-fractionalizer/src/params.rs
+++ b/cis2-fractionalizer/src/params.rs
@@ -2,7 +2,10 @@ use concordium_cis2::*;
 use concordium_std::*;
 use core::convert::TryInto;
 
-use crate::{ContractTokenAmount, ContractTokenId};
+use crate::{
+    state::{CollateralKey, CollateralState},
+    ContractTokenAmount, ContractTokenId,
+};
 
 #[derive(Serial, Deserial, SchemaType)]
 pub struct TokenMintParams {
@@ -75,6 +78,7 @@ pub struct ViewAddressState {
 pub struct ViewState {
     pub state: Vec<(Address, ViewAddressState)>,
     pub tokens: Vec<ContractTokenId>,
+    pub collaterals: Vec<(CollateralKey, CollateralState)>,
 }
 
 /// Parameter type for the CIS-2 function `balanceOf` specialized to the subset

--- a/cis2-fractionalizer/src/params.rs
+++ b/cis2-fractionalizer/src/params.rs
@@ -1,0 +1,88 @@
+use concordium_cis2::*;
+use concordium_std::*;
+use core::convert::TryInto;
+
+use crate::{ContractTokenAmount, ContractTokenId};
+
+#[derive(Serial, Deserial, SchemaType)]
+pub struct TokenMintParams {
+    pub metadata: TokenMetadata,
+    pub amount: ContractTokenAmount,
+    pub contract: ContractAddress,
+    pub token_id: ContractTokenId,
+}
+
+/// The parameter for the contract function `mint` which mints a number of
+/// token types and/or amounts of tokens to a given address.
+#[derive(Serial, Deserial, SchemaType)]
+pub struct MintParams {
+    /// Owner of the newly minted tokens.
+    pub owner: Address,
+    /// A collection of tokens to mint.
+    pub tokens: collections::BTreeMap<ContractTokenId, TokenMintParams>,
+}
+
+/// The parameter type for the contract function `setImplementors`.
+/// Takes a standard identifier and a list of contract addresses providing
+/// implementations of this standard.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct SetImplementorsParams {
+    /// The identifier for the standard.
+    pub id: StandardIdentifierOwned,
+    /// The addresses of the implementors of the standard.
+    pub implementors: Vec<ContractAddress>,
+}
+
+#[derive(Debug, Serialize, Clone, SchemaType)]
+pub struct TokenMetadata {
+    /// The URL following the specification RFC1738.
+    #[concordium(size_length = 2)]
+    pub url: String,
+    /// A optional hash of the content.
+    #[concordium(size_length = 2)]
+    pub hash: String,
+}
+
+impl TokenMetadata {
+    fn get_hash_bytes(&self) -> Option<[u8; 32]> {
+        match hex::decode(self.hash.to_owned()) {
+            Ok(v) => {
+                let slice = v.as_slice();
+                match slice.try_into() {
+                    Ok(array) => Option::Some(array),
+                    Err(_) => Option::None,
+                }
+            }
+            Err(_) => Option::None,
+        }
+    }
+
+    pub(crate) fn to_metadata_url(&self) -> MetadataUrl {
+        MetadataUrl {
+            url: self.url.to_string(),
+            hash: self.get_hash_bytes(),
+        }
+    }
+}
+
+#[derive(Serialize, SchemaType)]
+pub struct ViewAddressState {
+    pub balances: Vec<(ContractTokenId, ContractTokenAmount)>,
+    pub operators: Vec<Address>,
+}
+
+#[derive(Serialize, SchemaType)]
+pub struct ViewState {
+    pub state: Vec<(Address, ViewAddressState)>,
+    pub tokens: Vec<ContractTokenId>,
+}
+
+/// Parameter type for the CIS-2 function `balanceOf` specialized to the subset
+/// of TokenIDs used by this contract.
+pub type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
+
+/// Response type for the CIS-2 function `balanceOf` specialized to the subset
+/// of TokenAmounts used by this contract.
+pub type ContractBalanceOfQueryResponse = BalanceOfQueryResponse<ContractTokenAmount>;
+
+pub type TransferParameter = TransferParams<ContractTokenId, ContractTokenAmount>;

--- a/cis2-fractionalizer/src/state.rs
+++ b/cis2-fractionalizer/src/state.rs
@@ -26,14 +26,14 @@ impl<S: HasStateApi> AddressState<S> {
     }
 }
 
-#[derive(Serial, Deserial, Clone)]
+#[derive(Serial, Deserial, Clone, SchemaType, Copy)]
 pub struct CollateralKey {
     pub contract: ContractAddress,
     pub token_id: ContractTokenId,
     pub owner: AccountAddress,
 }
 
-#[derive(Serial, Deserial, Clone, Copy)]
+#[derive(Serial, Deserial, Clone, Copy, SchemaType)]
 pub struct CollateralState {
     pub received_token_amount: ContractTokenAmount,
     pub minted_token_id: Option<ContractTokenId>,

--- a/cis2-fractionalizer/src/state.rs
+++ b/cis2-fractionalizer/src/state.rs
@@ -1,0 +1,317 @@
+use concordium_cis2::*;
+use concordium_std::{*};
+
+use crate::{
+    error::{ContractError, CustomContractError},
+    params::TokenMetadata,
+    ContractResult, ContractTokenAmount, ContractTokenId,
+};
+
+/// The state for each address.
+#[derive(Serial, DeserialWithState, Deletable, StateClone)]
+#[concordium(state_parameter = "S")]
+pub struct AddressState<S> {
+    /// The amount of tokens owned by this address.
+    pub(crate) balances: StateMap<ContractTokenId, ContractTokenAmount, S>,
+    /// The address which are currently enabled as operators for this address.
+    pub(crate) operators: StateSet<Address, S>,
+}
+
+impl<S: HasStateApi> AddressState<S> {
+    fn empty(state_builder: &mut StateBuilder<S>) -> Self {
+        AddressState {
+            balances: state_builder.new_map(),
+            operators: state_builder.new_set(),
+        }
+    }
+}
+
+#[derive(Serial, Deserial, Clone)]
+pub struct CollateralKey {
+    pub contract: ContractAddress,
+    pub token_id: ContractTokenId,
+    pub owner: AccountAddress,
+}
+
+#[derive(Serial, Deserial, Clone, Copy)]
+pub struct CollateralState {
+    pub received_token_amount: ContractTokenAmount,
+    pub minted_token_id: Option<ContractTokenId>,
+}
+
+impl CollateralState {
+    fn new() -> Self {
+        CollateralState {
+            received_token_amount: ContractTokenAmount::from(0),
+            minted_token_id: Option::None,
+        }
+    }
+}
+
+/// The contract state,
+///
+/// Note: The specification does not specify how to structure the contract state
+/// and this could be structured in a more space efficient way.
+#[derive(Serial, DeserialWithState, StateClone)]
+#[concordium(state_parameter = "S")]
+pub struct State<S> {
+    /// The state of addresses.
+    pub(crate) state: StateMap<Address, AddressState<S>, S>,
+    /// All of the token IDs
+    pub(crate) tokens: StateMap<ContractTokenId, MetadataUrl, S>,
+    /// Map with contract addresses providing implementations of additional
+    /// standards.
+    pub(crate) implementors: StateMap<StandardIdentifierOwned, Vec<ContractAddress>, S>,
+    pub(crate) collaterals: StateMap<CollateralKey, CollateralState, S>,
+}
+
+impl<S: HasStateApi> State<S> {
+    /// Construct a state with no tokens
+    pub(crate) fn empty(state_builder: &mut StateBuilder<S>) -> Self {
+        State {
+            state: state_builder.new_map(),
+            tokens: state_builder.new_map(),
+            implementors: state_builder.new_map(),
+            collaterals: state_builder.new_map(),
+        }
+    }
+
+    /// Mints an amount of tokens with a given address as the owner.
+    pub(crate) fn mint(
+        &mut self,
+        token_id: &ContractTokenId,
+        token_metadata: &TokenMetadata,
+        amount: ContractTokenAmount,
+        owner: &Address,
+        state_builder: &mut StateBuilder<S>,
+    ) {
+        self.tokens
+            .insert(*token_id, token_metadata.to_metadata_url());
+        let mut owner_state = self
+            .state
+            .entry(*owner)
+            .or_insert_with(|| AddressState::empty(state_builder));
+        let mut owner_balance = owner_state.balances.entry(*token_id).or_insert(0.into());
+        *owner_balance += amount;
+    }
+
+    pub(crate) fn burn(
+        &mut self,
+        token_id: &ContractTokenId,
+        amount: ContractTokenAmount,
+        owner: &Address,
+    ) -> ContractResult<ContractTokenAmount> {
+        match self.state.get_mut(owner) {
+            Some(address_state) => match address_state.balances.get_mut(token_id) {
+                Some(mut b) => {
+                    ensure!(
+                        b.cmp(&amount).is_ge(),
+                        Cis2Error::Custom(CustomContractError::NoBalanceToBurn)
+                    );
+
+                    *b -= amount;
+                    Ok(*b)
+                }
+                None => Err(Cis2Error::Custom(CustomContractError::NoBalanceToBurn)),
+            },
+            None => Err(Cis2Error::Custom(CustomContractError::NoBalanceToBurn)),
+        }
+    }
+
+    /// Check that the token ID currently exists in this contract.
+    #[inline(always)]
+    pub(crate) fn contains_token(&self, token_id: &ContractTokenId) -> bool {
+        self.tokens.get(token_id).is_some()
+    }
+
+    /// Get the current balance of a given token id for a given address.
+    /// Results in an error if the token id does not exist in the state.
+    pub(crate) fn balance(
+        &self,
+        token_id: &ContractTokenId,
+        address: &Address,
+    ) -> ContractResult<ContractTokenAmount> {
+        ensure!(self.contains_token(token_id), ContractError::InvalidTokenId);
+        let balance = self.state.get(address).map_or(0.into(), |address_state| {
+            address_state
+                .balances
+                .get(token_id)
+                .map_or(0.into(), |x| *x)
+        });
+        Ok(balance)
+    }
+
+    /// Check if an address is an operator of a given owner address.
+    pub(crate) fn is_operator(&self, address: &Address, owner: &Address) -> bool {
+        self.state
+            .get(owner)
+            .map(|address_state| address_state.operators.contains(address))
+            .unwrap_or(false)
+    }
+
+    /// Update the state with a transfer.
+    /// Results in an error if the token id does not exist in the state or if
+    /// the from address have insufficient tokens to do the transfer.
+    pub(crate) fn transfer(
+        &mut self,
+        token_id: &ContractTokenId,
+        amount: ContractTokenAmount,
+        from: &Address,
+        to: &Address,
+        state_builder: &mut StateBuilder<S>,
+    ) -> ContractResult<()> {
+        ensure!(self.contains_token(token_id), ContractError::InvalidTokenId);
+        // A zero transfer does not modify the state.
+        if amount == 0.into() {
+            return Ok(());
+        }
+
+        // Get the `from` state and balance, if not present it will fail since the
+        // balance is interpreted as 0 and the transfer amount must be more than
+        // 0 as this point.;
+        {
+            let mut from_address_state = self
+                .state
+                .entry(*from)
+                .occupied_or(ContractError::InsufficientFunds)?;
+            let mut from_balance = from_address_state
+                .balances
+                .entry(*token_id)
+                .occupied_or(ContractError::InsufficientFunds)?;
+            ensure!(*from_balance >= amount, ContractError::InsufficientFunds);
+            *from_balance -= amount;
+        }
+
+        let mut to_address_state = self
+            .state
+            .entry(*to)
+            .or_insert_with(|| AddressState::empty(state_builder));
+        let mut to_address_balance = to_address_state
+            .balances
+            .entry(*token_id)
+            .or_insert(0.into());
+        *to_address_balance += amount;
+
+        Ok(())
+    }
+
+    /// Update the state adding a new operator for a given address.
+    /// Succeeds even if the `operator` is already an operator for the
+    /// `address`.
+    pub(crate) fn add_operator(
+        &mut self,
+        owner: &Address,
+        operator: &Address,
+        state_builder: &mut StateBuilder<S>,
+    ) {
+        let mut owner_state = self
+            .state
+            .entry(*owner)
+            .or_insert_with(|| AddressState::empty(state_builder));
+        owner_state.operators.insert(*operator);
+    }
+
+    /// Update the state removing an operator for a given address.
+    /// Succeeds even if the `operator` is not an operator for the `address`.
+    pub(crate) fn remove_operator(&mut self, owner: &Address, operator: &Address) {
+        self.state.entry(*owner).and_modify(|address_state| {
+            address_state.operators.remove(operator);
+        });
+    }
+
+    /// Check if state contains any implementors for a given standard.
+    pub(crate) fn have_implementors(&self, std_id: &StandardIdentifierOwned) -> SupportResult {
+        if let Some(addresses) = self.implementors.get(std_id) {
+            SupportResult::SupportBy(addresses.to_vec())
+        } else {
+            SupportResult::NoSupport
+        }
+    }
+
+    pub(crate) fn add_collateral(
+        &mut self,
+        contract: ContractAddress,
+        token_id: ContractTokenId,
+        owner: AccountAddress,
+        received_token_amount: ContractTokenAmount,
+    ) {
+        let key = CollateralKey {
+            contract,
+            token_id,
+            owner,
+        };
+
+        let mut cs = match self.collaterals.get(&key) {
+            Some(v) => *v,
+            None => CollateralState::new(),
+        };
+
+        cs.received_token_amount += received_token_amount;
+
+        self.collaterals.insert(key, cs);
+    }
+
+    pub(crate) fn has_collateral(
+        &self,
+        contract: &ContractAddress,
+        token_id: &ContractTokenId,
+        owner: &AccountAddress,
+    ) -> bool {
+        let key = CollateralKey {
+            contract: *contract,
+            token_id: *token_id,
+            owner: *owner,
+        };
+
+        self.collaterals.get(&key).is_some()
+    }
+
+    pub(crate) fn find_collateral(
+        &self,
+        token_id: &ContractTokenId,
+    ) -> Option<(CollateralKey, ContractTokenAmount)> {
+        for c in self.collaterals.iter() {
+            match c.1.minted_token_id {
+                Some(t) => {
+                    if t.eq(token_id) {
+                        return Some((c.0.clone(), c.1.received_token_amount));
+                    }
+                }
+                None => continue,
+            };
+        }
+
+        None
+    }
+
+    pub(crate) fn update_collateral_token(
+        &mut self,
+        contract: ContractAddress,
+        token_id: ContractTokenId,
+        owner: AccountAddress,
+        minted_token_id: ContractTokenId,
+    ) -> ContractResult<()> {
+        let key = CollateralKey {
+            contract,
+            token_id,
+            owner,
+        };
+
+        match self.collaterals.entry(key) {
+            Entry::Vacant(_) => bail!(Cis2Error::Custom(CustomContractError::InvalidCollateral)),
+            Entry::Occupied(mut e) => {
+                e.modify(|s| s.minted_token_id = Some(minted_token_id));
+                Ok(())
+            }
+        }
+    }
+
+    /// Set implementors for a given standard.
+    pub(crate) fn set_implementors(
+        &mut self,
+        std_id: StandardIdentifierOwned,
+        implementors: Vec<ContractAddress>,
+    ) {
+        self.implementors.insert(std_id, implementors);
+    }
+}

--- a/concordium-client/README.md
+++ b/concordium-client/README.md
@@ -31,6 +31,7 @@ here the `WASM-FILE-PATH` can be
 - [cis2-nft wasm](../cis2-nft/module.wasm)
 - [cis2-multi wasm](../cis2-multi/module.wasm)
 - [marketplace wasm](../marketplace-contract/module.wasm)
+- [Fractionalizer wasm](../cis2-fractionalizer/module.wasm)
 
 You can [read more](https://developer.concordium.software/en/mainnet/net/references/concordium-client.html#concordium-client) about `concordium-client` and its cli params like `--grpc-ip` & `--grpc-port`
 
@@ -51,3 +52,4 @@ Here lets for the context of this repository name our contracts in the following
 - [CIS2 NFT](./cis2-nft.README.md)
 - [CIS2 Multi](./cis2-multi.README.md)
 - [Marketplace](./marketplace-contract.README.md)
+- [CIS2 Fractionalizer](./cis2-fractionalizer.README.md)

--- a/concordium-client/cis2-fractionalizer.README.md
+++ b/concordium-client/cis2-fractionalizer.README.md
@@ -1,0 +1,34 @@
+- Perquisites
+
+  - A CIS2 Compatible Contract Instance with atleast 1 minted token (Please see [cis2-multi instructions](./cis2-multi.README.md) to do the same)
+
+- Initialize Smart Contract
+
+  ```bash
+  concordium-client --grpc-ip $GRPC_IP --grpc-port $GRPC_PORT contract init <MODULE_REF> --contract CIS2-Fractionalizer --sender $ACCOUNT --energy 3000
+  ```
+
+- Transfer CIS2 Token to the Fractionalizer Contract
+
+  ```
+  concordium-client --grpc-ip $GRPC_IP --grpc-port $GRPC_PORT contract update 2164 --entrypoint transfer --parameter-json ../sample-artifacts/cis2-fractionalizer/cis2-multi-transfer.json --schema ../cis2-multi/schema.bin --sender $ACCOUNT --energy 6000
+  ```
+
+- Mint
+
+  ```bash
+  concordium-client --grpc-ip $GRPC_IP --grpc-port $GRPC_PORT contract update 2163 --entrypoint mint --parameter-json ../sample-artifacts/cis2-fractionalizer/mint.json --schema ../cis2-fractionalizer/schema.bin --sender $ACCOUNT --energy 6000
+  ```
+
+- Burn
+
+  We transfer some part of the amount of the minted tokens back to the contract address to burn the tokens
+
+  ```bash
+  concordium-client --grpc-ip $GRPC_IP --grpc-port $GRPC_PORT contract update 2163 --entrypoint transfer --parameter-json ../sample-artifacts/cis2-fractionalizer/burn-20.json --schema ../cis2-fractionalizer/schema.bin --sender $ACCOUNT --energy 6000
+  ```
+  ```bash
+  concordium-client --grpc-ip $GRPC_IP --grpc-port $GRPC_PORT contract update 2163 --entrypoint transfer --parameter-json ../sample-artifacts/cis2-fractionalizer/burn-80.json --schema ../cis2-fractionalizer/schema.bin --sender $ACCOUNT --energy 6000
+  ```
+
+- [View CIS2-Multi](./cis2-multi.README.md)

--- a/sample-artifacts/cis2-fractionalizer/burn-20.json
+++ b/sample-artifacts/cis2-fractionalizer/burn-20.json
@@ -1,0 +1,13 @@
+[
+	{
+		"token_id": "01",
+		"amount": "20",
+		"from": {
+			"Account": ["48x2Uo8xCMMxwGuSQnwbqjzKtVqK5MaUud4vG7QEUgDmYkV85e"]
+		},
+		"to": {
+			"Contract": [{ "index": 2163, "subindex": 0 }, ""]
+		},
+		"data": ""
+	}
+]

--- a/sample-artifacts/cis2-fractionalizer/burn-80.json
+++ b/sample-artifacts/cis2-fractionalizer/burn-80.json
@@ -1,0 +1,13 @@
+[
+	{
+		"token_id": "01",
+		"amount": "80",
+		"from": {
+			"Account": ["48x2Uo8xCMMxwGuSQnwbqjzKtVqK5MaUud4vG7QEUgDmYkV85e"]
+		},
+		"to": {
+			"Contract": [{ "index": 2163, "subindex": 0 }, ""]
+		},
+		"data": ""
+	}
+]

--- a/sample-artifacts/cis2-fractionalizer/cis2-multi-transfer.json
+++ b/sample-artifacts/cis2-fractionalizer/cis2-multi-transfer.json
@@ -1,0 +1,13 @@
+[
+	{
+		"token_id": "01",
+		"amount": "20",
+		"from": {
+			"Account": ["48x2Uo8xCMMxwGuSQnwbqjzKtVqK5MaUud4vG7QEUgDmYkV85e"]
+		},
+		"to": {
+			"Contract": [{ "index": 2163, "subindex": 0 }, "onReceivingCIS2"]
+		},
+		"data": ""
+	}
+]

--- a/sample-artifacts/cis2-fractionalizer/mint.json
+++ b/sample-artifacts/cis2-fractionalizer/mint.json
@@ -1,0 +1,19 @@
+{
+	"owner": {
+		"Account": ["48x2Uo8xCMMxwGuSQnwbqjzKtVqK5MaUud4vG7QEUgDmYkV85e"]
+	},
+	"tokens": [
+		[
+			"01",
+			{
+				"metadata": {
+					"url": "https://ipfs.io/ipfs/QmV5REE3HJRLTHdmqG18Wc5PBF3Nc9W5dQL4Rp7MxBsx8q?filename=nft.jpg",
+					"hash": "db2ca420a0090593ac6559ff2a98ce30abfe665d7a18ff3c63883e8b98622a73"
+				},
+				"amount": "100",
+				"contract": { "index": 2164, "subindex": 0 },
+				"token_id": "01"
+			}
+		]
+	]
+}


### PR DESCRIPTION
Added Fractionalizer Contract. 

Process
- Use any CIS2 Contract to transfer tokens to Fractionalizer Contract with function name `onReceivingCIS2`
- Mint a token on Fractionalizer Contract using the transferred token id as collateral
- Newly Minted token can now be used as a normal CIS2 Token (Fractionalizer supports CIS2)
- Transferring the token back to Fractionalizer contract (On which the token was minted) burns the token
- When the token supply is fully burnt. Collateral Token is transferred back
